### PR TITLE
Extend festival endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Maven
+/target/
+!.mvn/wrapper/maven-wrapper.jar
+
+# IDEs
+.idea/
+*.iml
+
+# OS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# Texnologia_Logismikou
+# Texnologia Logismikou
+
+This repository contains the backend implementation for a music festival management system. It is built using Java, Spring Boot, and Maven.
+
+## Building and Running
+
+```bash
+mvn spring-boot:run
+```
+
+The application exposes basic REST endpoints:
+
+- `POST /festivals` – create a new festival
+- `GET /festivals` – list all festivals
+- `GET /festivals?name=&description=&startDate=&endDate=&location=` – search festivals with optional filters
+- `GET /festivals/{id}` – view festival details
+- `PUT /festivals/{id}` – update a festival
+- `DELETE /festivals/{id}` – delete a festival
+- `PUT /festivals/{id}/status` – update festival status
+
+## Testing
+
+```bash
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>festival-management</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Festival Management</name>
+    <description>Backend service for managing music festivals</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/festival/FestivalApplication.java
+++ b/src/main/java/com/example/festival/FestivalApplication.java
@@ -1,0 +1,12 @@
+package com.example.festival;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class FestivalApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(FestivalApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/festival/FestivalController.java
+++ b/src/main/java/com/example/festival/FestivalController.java
@@ -1,0 +1,77 @@
+package com.example.festival;
+
+import com.example.festival.model.Festival;
+import com.example.festival.service.FestivalService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+import java.util.List;
+
+@RestController
+public class FestivalController {
+
+    private final FestivalService service = new FestivalService();
+
+    @GetMapping("/")
+    public String index() {
+        return "Welcome to the Festival Management API";
+    }
+
+    @PostMapping("/festivals")
+    public ResponseEntity<Festival> createFestival(@RequestBody Festival festival) {
+        try {
+            Festival created = service.createFestival(festival);
+            return ResponseEntity.ok(created);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping("/festivals")
+    public List<Festival> listFestivals(@RequestParam(required = false) String name,
+                                        @RequestParam(required = false) String description,
+                                        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+                                        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+                                        @RequestParam(required = false) String location) {
+        boolean hasFilters = name != null || description != null || startDate != null || endDate != null || location != null;
+        if (hasFilters) {
+            return service.searchFestivals(name, description, startDate, endDate, location);
+        }
+        return service.getFestivals();
+    }
+
+    @GetMapping("/festivals/{id}")
+    public ResponseEntity<Festival> getFestival(@PathVariable Long id) {
+        return service.getFestival(id)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/festivals/{id}")
+    public ResponseEntity<Festival> updateFestival(@PathVariable Long id,
+                                                   @RequestBody Festival festival) {
+        return service.updateFestival(id, festival)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/festivals/{id}")
+    public ResponseEntity<Void> deleteFestival(@PathVariable Long id) {
+        boolean deleted = service.deleteFestival(id);
+        return deleted ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+
+    @PutMapping("/festivals/{id}/status")
+    public ResponseEntity<Festival> setStatus(@PathVariable Long id,
+                                              @RequestBody Festival festival) {
+        if (festival.getStatus() == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        return service.setStatus(id, festival.getStatus())
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/example/festival/model/Festival.java
+++ b/src/main/java/com/example/festival/model/Festival.java
@@ -1,0 +1,80 @@
+package com.example.festival.model;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class Festival {
+    private Long id;
+    private String name;
+    private String description;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String location;
+    private FestivalStatus status = FestivalStatus.CREATED;
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    // getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public FestivalStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(FestivalStatus status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/example/festival/model/FestivalStatus.java
+++ b/src/main/java/com/example/festival/model/FestivalStatus.java
@@ -1,0 +1,12 @@
+package com.example.festival.model;
+
+public enum FestivalStatus {
+    CREATED,
+    SUBMISSION,
+    ASSIGNMENT,
+    REVIEW,
+    SCHEDULING,
+    FINAL_SUBMISSION,
+    DECISION,
+    ANNOUNCED
+}

--- a/src/main/java/com/example/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/example/festival/repository/FestivalRepository.java
@@ -1,0 +1,37 @@
+package com.example.festival.repository;
+
+import com.example.festival.model.Festival;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class FestivalRepository {
+    private final Map<Long, Festival> storage = new HashMap<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+
+    public Festival save(Festival festival) {
+        if (festival.getId() == null) {
+            festival.setId(idGenerator.getAndIncrement());
+        }
+        storage.put(festival.getId(), festival);
+        return festival;
+    }
+
+    public Optional<Festival> findById(Long id) {
+        return Optional.ofNullable(storage.get(id));
+    }
+
+    public List<Festival> findAll() {
+        return new ArrayList<>(storage.values());
+    }
+
+    public Optional<Festival> findByName(String name) {
+        return storage.values().stream()
+                .filter(f -> f.getName().equalsIgnoreCase(name))
+                .findFirst();
+    }
+
+    public boolean delete(Long id) {
+        return storage.remove(id) != null;
+    }
+}

--- a/src/main/java/com/example/festival/service/FestivalService.java
+++ b/src/main/java/com/example/festival/service/FestivalService.java
@@ -1,0 +1,86 @@
+package com.example.festival.service;
+
+import com.example.festival.model.Festival;
+import com.example.festival.model.FestivalStatus;
+import com.example.festival.repository.FestivalRepository;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class FestivalService {
+    private final FestivalRepository repository = new FestivalRepository();
+
+    public Festival createFestival(Festival festival) {
+        if (festival.getName() == null || festival.getName().isBlank()) {
+            throw new IllegalArgumentException("Name is required");
+        }
+        repository.findByName(festival.getName()).ifPresent(f -> {
+            throw new IllegalArgumentException("Festival name must be unique");
+        });
+        return repository.save(festival);
+    }
+
+    public Optional<Festival> getFestival(Long id) {
+        return repository.findById(id);
+    }
+
+    public List<Festival> getFestivals() {
+        return repository.findAll();
+    }
+
+    public List<Festival> searchFestivals(String name, String description,
+                                           LocalDate startDate, LocalDate endDate,
+                                           String location) {
+        List<Festival> festivals = repository.findAll();
+        return festivals.stream()
+                .filter(f -> name == null || f.getName().toLowerCase().contains(name.toLowerCase()))
+                .filter(f -> description == null ||
+                        f.getDescription() != null && f.getDescription().toLowerCase().contains(description.toLowerCase()))
+                .filter(f -> location == null ||
+                        f.getLocation() != null && f.getLocation().toLowerCase().contains(location.toLowerCase()))
+                .filter(f -> startDate == null || (f.getStartDate() != null && !f.getStartDate().isBefore(startDate)))
+                .filter(f -> endDate == null || (f.getEndDate() != null && !f.getEndDate().isAfter(endDate)))
+                .sorted(Comparator.comparing(Festival::getStartDate, Comparator.nullsLast(Comparator.naturalOrder()))
+                        .thenComparing(Festival::getName, Comparator.nullsLast(String::compareToIgnoreCase)))
+                .collect(Collectors.toList());
+    }
+
+    public Optional<Festival> updateFestival(Long id, Festival data) {
+        Optional<Festival> existing = repository.findById(id);
+        existing.ifPresent(f -> {
+            if (data.getName() != null) {
+                f.setName(data.getName());
+            }
+            if (data.getDescription() != null) {
+                f.setDescription(data.getDescription());
+            }
+            if (data.getStartDate() != null) {
+                f.setStartDate(data.getStartDate());
+            }
+            if (data.getEndDate() != null) {
+                f.setEndDate(data.getEndDate());
+            }
+            if (data.getLocation() != null) {
+                f.setLocation(data.getLocation());
+            }
+            repository.save(f);
+        });
+        return existing;
+    }
+
+    public boolean deleteFestival(Long id) {
+        return repository.delete(id);
+    }
+
+    public Optional<Festival> setStatus(Long id, FestivalStatus status) {
+        Optional<Festival> existing = repository.findById(id);
+        existing.ifPresent(f -> {
+            f.setStatus(status);
+            repository.save(f);
+        });
+        return existing;
+    }
+}

--- a/src/test/java/com/example/festival/FestivalControllerTest.java
+++ b/src/test/java/com/example/festival/FestivalControllerTest.java
@@ -1,0 +1,107 @@
+package com.example.festival;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FestivalControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void indexReturnsWelcomeMessage() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Welcome to the Festival Management API"));
+    }
+
+    @Test
+    void createFestival() throws Exception {
+        Map<String, Object> payload = Map.of(
+                "name", "RockFest",
+                "description", "Annual rock festival",
+                "startDate", LocalDate.now().toString(),
+                "endDate", LocalDate.now().plusDays(2).toString(),
+                "location", "Athens"
+        );
+
+        mockMvc.perform(post("/festivals")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.name").value("RockFest"));
+    }
+
+    @Test
+    void updateAndDeleteFestival() throws Exception {
+        Map<String, Object> payload = Map.of(
+                "name", "JazzFest",
+                "description", "Annual jazz festival",
+                "startDate", LocalDate.now().toString(),
+                "endDate", LocalDate.now().plusDays(1).toString(),
+                "location", "Athens"
+        );
+
+        String response = mockMvc.perform(post("/festivals")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        Long id = objectMapper.readTree(response).get("id").asLong();
+
+        Map<String, Object> updatePayload = Map.of(
+                "description", "Updated"
+        );
+
+        mockMvc.perform(put("/festivals/" + id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatePayload)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.description").value("Updated"));
+
+        mockMvc.perform(delete("/festivals/" + id))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/festivals/" + id))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void searchFestivalsByName() throws Exception {
+        Map<String, Object> payload = Map.of(
+                "name", "SearchFest",
+                "description", "Test festival",
+                "startDate", LocalDate.now().toString(),
+                "endDate", LocalDate.now().plusDays(1).toString(),
+                "location", "Patras"
+        );
+
+        mockMvc.perform(post("/festivals")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/festivals")
+                        .param("name", "SearchFest"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("SearchFest"));
+    }
+}


### PR DESCRIPTION
## Summary
- support updating, deleting, and changing festival status
- expose new endpoints and document them in README
- cover update and delete logic with tests
- add festival search with optional filters

## Testing
- `mvn test` *(fails: Non-resolvable parent POM because network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6863d5247e008333ad32627e6d27408f